### PR TITLE
[fix]. 沈没した船の先端ラベルをtd中央に #1

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -2,7 +2,7 @@ module Main exposing (..)
 
 import Array exposing (Array)
 import Browser
-import Html exposing (Html, div, i, table, tbody, td, text, tr)
+import Html exposing (Html, div, i, table, tbody, td, text, tr, span)
 import Html.Attributes exposing (class)
 
 
@@ -170,7 +170,10 @@ viewSquare state =
 
         Sunk shipType (Tip direction) ->
             td [ class <| "sunk " ++ directionToString direction ]
-                [ div [] [ text <| shipTypeToString shipType ] ]
+                [ 
+                    div [] [], -- 図形表示用DOM
+                    span [] [text <| shipTypeToString shipType]
+                ]
 
         Miss ->
             td [] [ i [ class "fas fa-times" ] [] ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -2,7 +2,7 @@ module Main exposing (..)
 
 import Array exposing (Array)
 import Browser
-import Html exposing (Html, div, i, table, tbody, td, text, tr, span)
+import Html exposing (Html, div, i, span, table, tbody, td, text, tr)
 import Html.Attributes exposing (class)
 
 
@@ -170,9 +170,9 @@ viewSquare state =
 
         Sunk shipType (Tip direction) ->
             td [ class <| "sunk " ++ directionToString direction ]
-                [ 
-                    div [] [], -- 図形表示用DOM
-                    span [] [text <| shipTypeToString shipType]
+                [ div [] []
+                , -- 図形表示用DOM
+                  span [] [ text <| shipTypeToString shipType ]
                 ]
 
         Miss ->

--- a/src/scss/_table.scss
+++ b/src/scss/_table.scss
@@ -9,6 +9,7 @@ $tableSquareColor: #2bffff;
   border: 16px solid transparent;
   bottom: 0;
   left: 0;
+  z-index: -1;
 }
 
 table {


### PR DESCRIPTION
## 概要

沈没した船の先端ラベルをtd中央に必ず配置されるように修正しました

## 原因

水色の図形描写用DOMの**中にテキスト**が入っていたため、図形のcssに影響されてテキストがおかしく表示されてました。

なので

- 図形描写用DOMと別にテキスト表示DOMを作成
- 図形が上に重なってしまったので z-indexを調整
  - テキスト表示DOMの方に z-index: {大きい数}を当てましたが効かなかったので、 図形描写用DOMに-1をあてました
